### PR TITLE
Snakemake framekwork for plasmid analysis of ast-all assemblies

### DIFF
--- a/plasmid/.gitignore
+++ b/plasmid/.gitignore
@@ -1,0 +1,3 @@
+__pychache__
+.snakemake
+out

--- a/plasmid/Snakefile
+++ b/plasmid/Snakefile
@@ -1,0 +1,104 @@
+#!/usr/bin/env snakemake
+#
+# Analyze all-ast contigs for plasmids
+#
+import pandas as pd
+import os
+
+######################################################################
+#
+# set up enviroment and sample list
+#
+######################################################################
+
+#
+# ---------------- INPUTs ----------------
+#
+DATASET_DIR="/home/nbowers/bvbrc-dev/dev_container/NCBI_AMR_Codeathon/all-ast"
+CAT_FILENAME="dataset_catalog.json"
+TEST_CAT_FILENAME="/home/ac.curtish/NCBI_AMR_Codeathon/my-ast/dataset_catalog.head.json"
+#
+# ---------------- OUTPUTS ----------------
+#
+#OUT_DIR="/home/ac.curtish/NCBI_AMR_Codeathon/all-plasmid/out"
+OUT_DIR="out"
+ 
+#
+# ----------------- SAMPLE LIST -----------
+#
+include: "rules/parse_dataset_catalog.py"
+
+# load sample accessions/filenames from the catalog.json
+samplesRawDf = parse_ast_catalog(DATASET_DIR+"/"+CAT_FILENAME)
+#samplesRawDf = parse_ast_catalog(TEST_CAT_FILENAME)
+
+# FNA version with just filenames
+samplesRawDf["FNAF"] = samplesRawDf["FNA"].apply(os.path.basename)
+
+# load our blacklist of accessions to ignore
+blacklist = pd.read_csv("accessions_blacklist.tsv", sep='\t')
+
+# Filter out rows in samplesRaw where the 'accession' is in the blacklist
+samplesDf = samplesRawDf[~samplesRawDf['accession'].isin(blacklist['accession'])]
+print("Filtered Samples (blacklist): {0} rows, {1} columns.".format(*samplesDf.shape))
+
+samplesTup   = list(zip(*[samplesDf[col] for col in samplesDf.columns]))
+
+######################################################################
+#
+# RULES
+#
+######################################################################
+
+rule help: 
+	run:
+		print("--- help ----")
+		print("help: list top targets")
+		print("test: show top 10 samples")
+		print("wc: test running wc on top 100 fnas")
+		print("")
+
+rule test: 
+	run: 
+		print(samplesDf.head(n=10))
+
+
+# ----------------------------------------------------------------------
+# 
+# "wc" - test process
+#
+# process top 100 non-blacklisted samples
+#
+# ----------------------------------------------------------------------
+
+#
+# top level rule - samples to run
+#
+rule wc: 
+	input: expand(OUT_DIR + "/{accession}.txt", accession=samplesDf['accession'].head(n=10))
+
+#
+# wc test process
+# 
+# get wc for assembly fna
+#
+rule wc_proc_lamdba:
+	wildcard_constraints: ACC="GCA_[0-9]+\\.[0-9]+"
+	output: OUT_DIR+"/{ACC}.txt"
+	input: lambda wildcards: DATASET_DIR+"/"+samplesDf.loc[samplesDf['accession'] == wildcards.ACC, 'FNA'].values[0]
+	shell: "grep -H -c '>' {input} > {output}"
+
+rule wc_proc_no_lambda:
+	wildcard_constraints: ACC="GCA_[0-9]+\\.[0-9]+"
+	output: OUT_DIR+"/{ACC}_{EXTRA}.txt"
+	input: DATASET_DIR+"/{ACC}/{ACC}_{EXTRA}"
+	#input: lambda wildcards: samplesDf.loc[samplesDf['accession'] == wildcards.accession, 'FNA'].values[0]
+	shell: "grep -H -c '>' {input} > {output}"
+
+# ----------------------------------------------------------------------
+# 
+# "wc" - test process
+#
+# process top 100 non-blacklisted samples
+#
+# ----------------------------------------------------------------------

--- a/plasmid/Snakefile.wc_test
+++ b/plasmid/Snakefile.wc_test
@@ -1,0 +1,112 @@
+#!/usr/bin/env snakemake
+#
+# Analyze all-ast contigs for plasmids
+#
+import pandas as pd
+import os
+
+######################################################################
+#
+# set up enviroment and sample list
+#
+######################################################################
+
+#
+# ---------------- INPUTs ----------------
+#
+DATASET_DIR="/home/nbowers/bvbrc-dev/dev_container/NCBI_AMR_Codeathon/all-ast"
+CAT_FILENAME="dataset_catalog.json"
+TEST_CAT_FILENAME="/home/ac.curtish/NCBI_AMR_Codeathon/my-ast/dataset_catalog.head.json"
+#
+# ---------------- OUTPUTS ----------------
+#
+#OUT_DIR="/home/ac.curtish/NCBI_AMR_Codeathon/all-plasmid/out"
+OUT_DIR="out"
+ 
+#
+# ----------------- SAMPLE LIST -----------
+#
+include: "rules/parse_dataset_catalog.py"
+
+# load sample accessions/filenames from the catalog.json
+samplesRawDf = parse_ast_catalog(DATASET_DIR+"/"+CAT_FILENAME)
+#samplesRawDf = parse_ast_catalog(TEST_CAT_FILENAME)
+
+# FNA version with just filenames
+samplesRawDf["FNAF"] = samplesRawDf["FNA"].apply(os.path.basename)
+
+# load our blacklist of accessions to ignore
+blacklist = pd.read_csv("accessions_blacklist.tsv", sep='\t')
+
+# Filter out rows in samplesRaw where the 'accession' is in the blacklist
+samplesDf = samplesRawDf[~samplesRawDf['accession'].isin(blacklist['accession'])]
+print("Filtered Samples (blacklist): {0} rows, {1} columns.".format(*samplesDf.shape))
+
+samplesTup   = list(zip(*[samplesDf[col] for col in samplesDf.columns]))
+
+######################################################################
+#
+# RULES
+#
+######################################################################
+
+rule help: 
+	run:
+		print("--- help ----")
+		print("help: list top targets")
+		print("test: show top 10 samples")
+		print("wc: test running wc on top 100 fnas")
+		print("plasmids_x: Xioahui's models")
+		print("")
+
+rule test: 
+	run: 
+		print(samplesDf.head(n=10))
+
+
+# ----------------------------------------------------------------------
+# 
+# "wc" - test process
+#
+# process top 100 non-blacklisted samples
+#
+# ----------------------------------------------------------------------
+
+#
+# top level rule - samples to run
+#
+rule wc: 
+	input: expand(OUT_DIR + "/{accession}.txt", accession=samplesDf['accession'].head(n=10))
+
+#
+# wc test process
+# 
+# get wc for assembly fna
+#
+rule wc_proc_lamdba:
+	wildcard_constraints: ACC="GCA_[0-9]+\\.[0-9]+"
+	output: OUT_DIR+"/{ACC}.txt"
+	input: lambda wildcards: DATASET_DIR+"/"+samplesDf.loc[samplesDf['accession'] == wildcards.ACC, 'FNA'].values[0]
+	shell: "grep -H -c '>' {input} > {output}"
+
+rule wc_proc_no_lambda:
+	wildcard_constraints: ACC="GCA_[0-9]+\\.[0-9]+"
+	output: OUT_DIR+"/{ACC}_{EXTRA}.txt"
+	input: DATASET_DIR+"/{ACC}/{ACC}_{EXTRA}"
+	#input: lambda wildcards: samplesDf.loc[samplesDf['accession'] == wildcards.accession, 'FNA'].values[0]
+	shell: "grep -H -c '>' {input} > {output}"
+
+# ----------------------------------------------------------------------
+# 
+# "XIOAHUI" plasmid finder
+#
+# process top 1 non-blacklisted samples
+#
+# ----------------------------------------------------------------------
+rule plasmids_x:
+	wildcard_constraints: ACC="GCA_[0-9]+\\.[0-9]+"
+	output: OUT_DIR+"/{ACC}.txt"
+	input: lambda wildcards: DATASET_DIR+"/"+samplesDf.loc[samplesDf['accession'] == wildcards.ACC, 'FNA'].values[0]
+	shell: "grep -H -c '>' {input} > {output}"
+
+

--- a/plasmid/accessions_blacklist.tsv
+++ b/plasmid/accessions_blacklist.tsv
@@ -1,0 +1,2 @@
+accession	reason
+GCA_001246655.1	not decompressed

--- a/plasmid/rules/parse_dataset_catalog.py
+++ b/plasmid/rules/parse_dataset_catalog.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+#
+# Convert the AMR Codeathon AST assembly dataset_catalog.json into a DataFrame
+#
+#print("importing...")
+import argparse
+import json
+import pandas as pd
+
+
+def parse_ast_catalog(filename):
+
+	#print("opening: "+filename)
+	with open(filename) as f:
+	    data = json.load(f)
+
+	#print("loaded: "+filename)
+	# Prepare the list to store rows
+	rows = []
+
+	# Loop over each assembly and extract required information
+	for assembly in data.get("assemblies", []):
+	    accession = assembly.get("accession", "")
+	    #print("accession: "+accession)
+	    genomic_nucleotide_fasta = ""
+	    gff3 = ""
+	    protein_fasta = ""
+    
+	    # Iterate through the files
+	    for file in assembly.get("files", []):
+	        if file["fileType"] == "GENOMIC_NUCLEOTIDE_FASTA":
+	            genomic_nucleotide_fasta = file["filePath"]
+	        elif file["fileType"] == "GFF3":
+	            gff3 = file["filePath"]
+	        elif file["fileType"] == "PROTEIN_FASTA":
+	            protein_fasta = file["filePath"]
+	    
+	    # Append the row data to the list
+	    rows.append({
+	        "accession": accession,
+	        "FNA": genomic_nucleotide_fasta,
+	        "GFF": gff3,
+	        "FAA": protein_fasta
+	    })
+
+	# Convert the list of rows into a DataFrame
+	df = pd.DataFrame(rows)
+
+	# Display the resulting DataFrame
+	print("Loaded "+filename+": {0} rows, {1} columns.".format(*df.shape))
+
+	# first line is empty, the JSON just contained a ref to the "assembly_data_report.jsonl" file
+	return(df.iloc[1:])

--- a/plasmid/rules/test_parse.py
+++ b/plasmid/rules/test_parse.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+#
+from parse_dataset_catalog import parse_ast_catalog
+
+DATASET_DIR="/home/nbowers/bvbrc-dev/dev_container/NCBI_AMR_Codeathon/all-ast"
+CAT_FILENAME="dataset_catalog.json"
+
+df = parse_ast_catalog(DATASET_DIR+"/"+CAT_FILENAME)
+
+print("   Read {0} rows, {1} columns.".format(*df.shape))


### PR DESCRIPTION
Snakefile uses rules/parse_dataset_catalog.py to read the  dataset_catalog.json file and extract the sample list (accessions) and filenames.

Current implementation just runs "wc" on each .fna, as a proof of concept.

To test "snakemake --cores 20 wc"